### PR TITLE
Fix 4GB part size limit in hori_buffer_len

### DIFF
--- a/horayzon/horizon.pyx
+++ b/horayzon/horizon.pyx
@@ -195,7 +195,7 @@ def horizon_gridded(
     # Allocate horizon array
     cdef float hori_buffer_size = (vec_norm.shape[0] * vec_norm.shape[1] *
                                    azim_num * 4) / (10.0 ** 9.0)
-    cdef int hori_buffer_len
+    cdef np.int64_t hori_buffer_len
     if hori_buffer_size <= hori_buffer_size_max:
         print("Horizon buffer size is below specified limit")
         hori_buffer_len = vec_norm.shape[0] * vec_norm.shape[1] * azim_num

--- a/horayzon/horizon.pyx
+++ b/horayzon/horizon.pyx
@@ -378,7 +378,7 @@ def horizon_locations(
     units_c = units.encode("utf-8")
 
     # Allocate horizon array
-    cdef int hori_buffer_len = vec_norm.shape[0] * azim_num
+    cdef np.int64_t hori_buffer_len = vec_norm.shape[0] * azim_num
     cdef np.ndarray[np.float32_t, ndim = 1, mode = "c"] \
         hori_buffer = np.empty(hori_buffer_len,  dtype=np.float32)
     hori_buffer.fill(np.nan)

--- a/horayzon/horizon.pyx
+++ b/horayzon/horizon.pyx
@@ -201,7 +201,7 @@ def horizon_gridded(
         hori_buffer_len = vec_norm.shape[0] * vec_norm.shape[1] * azim_num
     else:
         print("Horizon buffer size is restricted")
-        hori_buffer_len = int((hori_buffer_size_max * 10 ** 9) / 4) + 100000
+        hori_buffer_len = np.int64((hori_buffer_size_max * 10 ** 9) / 4) + 100000
         # add some "safety" memory to the buffer (-> 100000)
     cdef np.ndarray[np.float32_t, ndim = 1, mode = "c"] \
         hori_buffer = np.empty(hori_buffer_len,  dtype=np.float32)


### PR DESCRIPTION
When building HORAYZON on my 64-bit machine according to the `README`, the `int` are interpreted as `int32_t`. 

This is not an issue for most variables, however for the buffer length specified by `hori_buffer_size_max` in `horayzon.horizon.horizon_gridded`, which then gets used to specify the sizes of the parts in bits, this means I am limited to (2^31-1) bits, which is about 4GB. In some usecases (including mine), this means generating hundreds of files, which is unwanted.

I propose specifying the type of `hori_buffer_len` to avoid this.